### PR TITLE
feat: add visual anchors to homepage

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -10,7 +10,7 @@
   "social_linkedin": "LinkedIn",
   "social_github": "GitHub",
   "contact_note_global": "Recent work and links are below.",
-  "contact_note_talk": "If the work fits, LinkedIn is the easiest way to reach me. GitHub has recent code and project history.",
+  "contact_note_talk": "LinkedIn is the easiest way to reach me. GitHub has recent code and project history.",
   "work_hero_title": "Projects",
   "work_hero_description": "The current project list is on the home page.",
   "resume_hero_eyebrow": "Resume",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -10,7 +10,7 @@
   "social_linkedin": "LinkedIn",
   "social_github": "GitHub",
   "contact_note_global": "最近の作業とリンクを下にまとめています。",
-  "contact_note_talk": "仕事の話であればLinkedInが一番見やすいです。GitHubには最近のコードと作業履歴があります。",
+  "contact_note_talk": "連絡はLinkedInが一番使いやすいです。GitHubには最近のコードと作業履歴があります。",
   "work_hero_title": "プロジェクト",
   "work_hero_description": "現在のプロジェクト一覧はトップページにあります。",
   "resume_hero_eyebrow": "経歴",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -10,7 +10,7 @@
   "social_linkedin": "LinkedIn",
   "social_github": "GitHub",
   "contact_note_global": "최근 작업과 링크를 아래에 정리했습니다.",
-  "contact_note_talk": "일이 맞는 경우 LinkedIn으로 연락 주시면 됩니다. GitHub에는 최근 코드와 작업 이력이 있습니다.",
+  "contact_note_talk": "연락은 LinkedIn이 가장 편합니다. GitHub에는 최근 코드와 작업 이력이 있습니다.",
   "work_hero_title": "프로젝트",
   "work_hero_description": "현재 프로젝트 목록은 메인 페이지에 있습니다.",
   "resume_hero_eyebrow": "이력",

--- a/src/lib/assets/icon/line/BaseLineIcon.svelte
+++ b/src/lib/assets/icon/line/BaseLineIcon.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  const {
+    size = '1rem',
+    viewBox = '0 0 24 24',
+    children
+  } = $props<{ size?: string; viewBox?: string; children?: Snippet }>();
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox={viewBox}
+  width={size}
+  height={size}
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.7"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  {@render children?.()}
+</svg>

--- a/src/lib/assets/icon/line/BriefcaseIcon.svelte
+++ b/src/lib/assets/icon/line/BriefcaseIcon.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import BaseLineIcon from './BaseLineIcon.svelte';
+
+  const { size = '1rem' } = $props<{ size?: string }>();
+</script>
+
+<BaseLineIcon {size}>
+  <rect x="3.5" y="7.25" width="17" height="11.5" rx="2" />
+  <path d="M9 7.25V5.75C9 4.78 9.78 4 10.75 4H13.25C14.22 4 15 4.78 15 5.75V7.25" />
+  <path d="M3.5 11.5H20.5" />
+</BaseLineIcon>

--- a/src/lib/assets/icon/line/FolderIcon.svelte
+++ b/src/lib/assets/icon/line/FolderIcon.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import BaseLineIcon from './BaseLineIcon.svelte';
+
+  const { size = '1rem' } = $props<{ size?: string }>();
+</script>
+
+<BaseLineIcon {size}>
+  <path d="M3.5 7.5C3.5 6.4 4.4 5.5 5.5 5.5H9L10.75 7.25H18.5C19.6 7.25 20.5 8.15 20.5 9.25V17.5C20.5 18.6 19.6 19.5 18.5 19.5H5.5C4.4 19.5 3.5 18.6 3.5 17.5V7.5Z" />
+</BaseLineIcon>

--- a/src/lib/assets/icon/line/LanguagesIcon.svelte
+++ b/src/lib/assets/icon/line/LanguagesIcon.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import BaseLineIcon from './BaseLineIcon.svelte';
+
+  const { size = '1rem' } = $props<{ size?: string }>();
+</script>
+
+<BaseLineIcon {size}>
+  <path d="M4 7.25H13" />
+  <path d="M8.5 5V7.25C8.5 10.35 6.7 12.8 4.5 14.5" />
+  <path d="M8.5 10.25C9.35 11.75 10.55 13.15 12 14.25" />
+  <path d="M14.5 19L17.75 10L21 19" />
+  <path d="M15.45 16.25H20.05" />
+</BaseLineIcon>

--- a/src/lib/assets/icon/line/LayersIcon.svelte
+++ b/src/lib/assets/icon/line/LayersIcon.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import BaseLineIcon from './BaseLineIcon.svelte';
+
+  const { size = '1rem' } = $props<{ size?: string }>();
+</script>
+
+<BaseLineIcon {size}>
+  <path d="M12 4L20 8.5L12 13L4 8.5L12 4Z" />
+  <path d="M6.25 12L12 15.25L17.75 12" />
+  <path d="M8.25 15.5L12 17.75L15.75 15.5" />
+</BaseLineIcon>

--- a/src/lib/assets/icon/line/MailIcon.svelte
+++ b/src/lib/assets/icon/line/MailIcon.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import BaseLineIcon from './BaseLineIcon.svelte';
+
+  const { size = '1rem' } = $props<{ size?: string }>();
+</script>
+
+<BaseLineIcon {size}>
+  <rect x="3.5" y="5.5" width="17" height="13" rx="2" />
+  <path d="M4.75 7L12 12.25L19.25 7" />
+</BaseLineIcon>

--- a/src/lib/assets/icon/line/MapPinIcon.svelte
+++ b/src/lib/assets/icon/line/MapPinIcon.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import BaseLineIcon from './BaseLineIcon.svelte';
+
+  const { size = '1rem' } = $props<{ size?: string }>();
+</script>
+
+<BaseLineIcon {size}>
+  <path d="M12 20C15.5 15.9 18 12.84 18 9.5A6 6 0 1 0 6 9.5C6 12.84 8.5 15.9 12 20Z" />
+  <circle cx="12" cy="9.5" r="2" />
+</BaseLineIcon>

--- a/src/lib/assets/icon/line/UserIcon.svelte
+++ b/src/lib/assets/icon/line/UserIcon.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import BaseLineIcon from './BaseLineIcon.svelte';
+
+  const { size = '1rem' } = $props<{ size?: string }>();
+</script>
+
+<BaseLineIcon {size}>
+  <circle cx="12" cy="8" r="3.25" />
+  <path d="M5 19.25C6.8 15.8 9.1 14.25 12 14.25C14.9 14.25 17.2 15.8 19 19.25" />
+</BaseLineIcon>

--- a/src/lib/assets/icon/line/WrenchIcon.svelte
+++ b/src/lib/assets/icon/line/WrenchIcon.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import BaseLineIcon from './BaseLineIcon.svelte';
+
+  const { size = '1rem' } = $props<{ size?: string }>();
+</script>
+
+<BaseLineIcon {size}>
+  <path d="M14.75 5.25A4.2 4.2 0 0 1 19 10.9L11.35 18.55A2.1 2.1 0 1 1 8.38 15.58L16.03 7.93A4.2 4.2 0 0 1 14.75 5.25Z" />
+  <path d="M13.7 6.3L17.7 10.3" />
+</BaseLineIcon>

--- a/src/views/pages/top/Page.svelte
+++ b/src/views/pages/top/Page.svelte
@@ -218,7 +218,7 @@
           </div>
         </div>
 
-        <div class="intro-grid">
+        <div class="section-content intro-grid">
           <dl class="facts">
             {#each facts as fact (fact.label)}
               {@const FactIcon = fact.icon}
@@ -263,7 +263,7 @@
           </div>
         </div>
 
-        <div class="entry-list">
+        <div class="section-content entry-list">
           {#each experiences as experience (experience.company + experience.role)}
             <article class="entry">
               <div class="entry-header">
@@ -299,7 +299,7 @@
           </div>
         </div>
 
-        <div class="entry-list">
+        <div class="section-content entry-list">
           {#each projects as project (project.name)}
             <article class="entry">
               <div class="entry-header">
@@ -329,7 +329,7 @@
           </div>
         </div>
 
-        <div class="skill-list">
+        <div class="section-content skill-list">
           {#each skillGroups as group (group.label)}
             <div class="skill-row">
               <p>{group.label}</p>
@@ -352,7 +352,7 @@
           </div>
         </div>
 
-        <div class="contact-block">
+        <div class="section-content contact-block">
           <p>{m.contact_note_talk()}</p>
           <div class="link-row">
             {#each socialLinks as link (link.href)}
@@ -518,9 +518,10 @@
   }
 
   .section-heading {
-    display: flex;
-    align-items: flex-start;
-    gap: 0.7rem;
+    display: grid;
+    grid-template-columns: 0.95rem minmax(0, 1fr);
+    align-items: start;
+    column-gap: 0.6rem;
   }
 
   .section-icon {
@@ -528,6 +529,10 @@
     color: #7f8894;
     padding-top: 0.1rem;
     flex-shrink: 0;
+  }
+
+  .section-content {
+    padding-left: calc(0.95rem + 0.6rem);
   }
 
   .intro-grid {
@@ -547,14 +552,19 @@
   }
 
   .fact-label {
-    display: inline-flex;
+    display: grid;
+    grid-template-columns: 0.82rem minmax(0, auto);
     align-items: center;
-    gap: 0.45rem;
+    column-gap: 0.45rem;
   }
 
   .fact-label :global(svg) {
     color: #6b7280;
     flex-shrink: 0;
+  }
+
+  .fact-row dd {
+    padding-left: calc(0.82rem + 0.45rem);
   }
 
   .links-block,
@@ -643,6 +653,10 @@
 
     .intro-grid {
       grid-template-columns: 1fr;
+    }
+
+    .section-content {
+      padding-left: 0;
     }
 
     .entry-header {

--- a/src/views/pages/top/Page.svelte
+++ b/src/views/pages/top/Page.svelte
@@ -526,7 +526,7 @@
 
   .section-icon {
     display: inline-flex;
-    color: #7f8894;
+    color: #b7c0cc;
     padding-top: 0.1rem;
     flex-shrink: 0;
   }
@@ -559,7 +559,7 @@
   }
 
   .fact-label :global(svg) {
-    color: #6b7280;
+    color: #a5b0bd;
     flex-shrink: 0;
   }
 
@@ -597,13 +597,29 @@
   .entry {
     display: grid;
     gap: 0.8rem;
-    padding: 1rem 0;
+    position: relative;
+    padding: 1rem 0 1rem 1rem;
     border-top: 1px solid #262b31;
+  }
+
+  .entry::before {
+    content: '-';
+    position: absolute;
+    top: 1rem;
+    left: 0;
+    color: #cfd8e3;
+    font-weight: 700;
+    font-size: 1rem;
+    line-height: 1;
   }
 
   .entry:first-child {
     padding-top: 0;
     border-top: none;
+  }
+
+  .entry:first-child::before {
+    top: 0;
   }
 
   .entry:last-child {
@@ -619,9 +635,26 @@
 
   ul {
     margin: 0;
-    padding-left: 1.1rem;
+    padding-left: 0;
+    list-style: none;
     display: grid;
     gap: 0.45rem;
+  }
+
+  li {
+    position: relative;
+    padding-left: 1rem;
+  }
+
+  li::before {
+    content: '-';
+    position: absolute;
+    top: 0;
+    left: 0;
+    color: #cfd8e3;
+    font-weight: 700;
+    font-size: 1rem;
+    line-height: 1;
   }
 
   .skill-list {
@@ -632,13 +665,30 @@
   .skill-row {
     display: grid;
     gap: 0.25rem;
+    position: relative;
     padding-top: 0.9rem;
+    padding-left: 1rem;
     border-top: 1px solid #262b31;
+  }
+
+  .skill-row::before {
+    content: '-';
+    position: absolute;
+    top: 0.9rem;
+    left: 0;
+    color: #cfd8e3;
+    font-weight: 700;
+    font-size: 1rem;
+    line-height: 1;
   }
 
   .skill-row:first-child {
     padding-top: 0;
     border-top: none;
+  }
+
+  .skill-row:first-child::before {
+    top: 0;
   }
 
   @media (max-width: 720px) {

--- a/src/views/pages/top/Page.svelte
+++ b/src/views/pages/top/Page.svelte
@@ -1,5 +1,18 @@
 <script lang="ts">
+  import type { Component } from 'svelte';
+  import Github from '$lib/assets/icon/Github.svelte';
+  import Linkedin from '$lib/assets/icon/Linkedin.svelte';
+  import BriefcaseIcon from '$lib/assets/icon/line/BriefcaseIcon.svelte';
+  import FolderIcon from '$lib/assets/icon/line/FolderIcon.svelte';
+  import LanguagesIcon from '$lib/assets/icon/line/LanguagesIcon.svelte';
+  import LayersIcon from '$lib/assets/icon/line/LayersIcon.svelte';
+  import MailIcon from '$lib/assets/icon/line/MailIcon.svelte';
+  import MapPinIcon from '$lib/assets/icon/line/MapPinIcon.svelte';
+  import UserIcon from '$lib/assets/icon/line/UserIcon.svelte';
+  import WrenchIcon from '$lib/assets/icon/line/WrenchIcon.svelte';
   import { m } from '$lib/paraglide/messages';
+
+  type IconComponent = Component<{ size?: string }>;
 
   type SectionLink = {
     target: string;
@@ -7,6 +20,7 @@
   };
 
   type Fact = {
+    icon: IconComponent;
     label: string;
     value: string;
   };
@@ -32,6 +46,7 @@
   };
 
   type SocialLink = {
+    icon: IconComponent;
     label: string;
     href: string;
   };
@@ -47,15 +62,22 @@
   const facts = $derived.by(
     (): Fact[] => [
       {
+        icon: BriefcaseIcon,
         label: m.resume_highlight_current_role_label(),
         value: m.resume_highlight_current_role_value()
       },
-      { label: m.resume_contact_base_label(), value: m.resume_contact_base_value() },
       {
+        icon: MapPinIcon,
+        label: m.resume_contact_base_label(),
+        value: m.resume_contact_base_value()
+      },
+      {
+        icon: LanguagesIcon,
         label: m.resume_contact_languages_label(),
         value: m.resume_contact_languages_value()
       },
       {
+        icon: LayersIcon,
         label: m.resume_highlight_toolbox_label(),
         value: m.resume_highlight_toolbox_value()
       }
@@ -149,8 +171,16 @@
 
   const socialLinks = $derived.by(
     (): SocialLink[] => [
-      { label: m.social_linkedin(), href: 'https://www.linkedin.com/in/dongwonttuna' },
-      { label: m.social_github(), href: 'https://github.com/dongwonttuna' }
+      {
+        icon: Linkedin,
+        label: m.social_linkedin(),
+        href: 'https://www.linkedin.com/in/dongwonttuna'
+      },
+      {
+        icon: Github,
+        label: m.social_github(),
+        href: 'https://github.com/dongwonttuna'
+      }
     ]
   );
 </script>
@@ -177,17 +207,28 @@
     <main class="document">
       <section class="panel" id="intro">
         <div class="section-header">
-          <div>
-            <p class="section-label">{m.hero_eyebrow()}</p>
-            <h2>{m.resume_hero_title()}</h2>
+          <div class="section-heading">
+            <span class="section-icon">
+              <UserIcon size="0.95rem" />
+            </span>
+            <div>
+              <p class="section-label">{m.hero_eyebrow()}</p>
+              <h2>{m.resume_hero_title()}</h2>
+            </div>
           </div>
         </div>
 
         <div class="intro-grid">
           <dl class="facts">
             {#each facts as fact (fact.label)}
+              {@const FactIcon = fact.icon}
               <div class="fact-row">
-                <dt>{fact.label}</dt>
+                <dt>
+                  <span class="fact-label">
+                    <FactIcon size="0.82rem" />
+                    <span>{fact.label}</span>
+                  </span>
+                </dt>
                 <dd>{fact.value}</dd>
               </div>
             {/each}
@@ -197,9 +238,11 @@
             <p>{m.contact_note_global()}</p>
             <div class="link-row">
               {#each socialLinks as link (link.href)}
+                {@const SocialIcon = link.icon}
                 <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
                 <a href={link.href} target="_blank" rel="noreferrer noopener">
-                  {link.label}
+                  <SocialIcon size="0.9rem" />
+                  <span>{link.label}</span>
                 </a>
               {/each}
             </div>
@@ -209,9 +252,14 @@
 
       <section class="panel" id="experience">
         <div class="section-header">
-          <div>
-            <p class="section-label">{m.resume_experience_eyebrow()}</p>
-            <h2>{m.resume_experience_title()}</h2>
+          <div class="section-heading">
+            <span class="section-icon">
+              <BriefcaseIcon size="0.95rem" />
+            </span>
+            <div>
+              <p class="section-label">{m.resume_experience_eyebrow()}</p>
+              <h2>{m.resume_experience_title()}</h2>
+            </div>
           </div>
         </div>
 
@@ -240,9 +288,14 @@
 
       <section class="panel" id="projects">
         <div class="section-header">
-          <div>
-            <p class="section-label">{m.resume_projects_eyebrow()}</p>
-            <h2>{m.resume_projects_title()}</h2>
+          <div class="section-heading">
+            <span class="section-icon">
+              <FolderIcon size="0.95rem" />
+            </span>
+            <div>
+              <p class="section-label">{m.resume_projects_eyebrow()}</p>
+              <h2>{m.resume_projects_title()}</h2>
+            </div>
           </div>
         </div>
 
@@ -265,9 +318,14 @@
 
       <section class="panel" id="skills">
         <div class="section-header">
-          <div>
-            <p class="section-label">{m.resume_skills_eyebrow()}</p>
-            <h2>{m.resume_skills_title()}</h2>
+          <div class="section-heading">
+            <span class="section-icon">
+              <WrenchIcon size="0.95rem" />
+            </span>
+            <div>
+              <p class="section-label">{m.resume_skills_eyebrow()}</p>
+              <h2>{m.resume_skills_title()}</h2>
+            </div>
           </div>
         </div>
 
@@ -283,9 +341,14 @@
 
       <section class="panel" id="contact">
         <div class="section-header">
-          <div>
-            <p class="section-label">{m.resume_certifications_eyebrow()}</p>
-            <h2>{m.resume_certifications_title()}</h2>
+          <div class="section-heading">
+            <span class="section-icon">
+              <MailIcon size="0.95rem" />
+            </span>
+            <div>
+              <p class="section-label">{m.resume_certifications_eyebrow()}</p>
+              <h2>{m.resume_certifications_title()}</h2>
+            </div>
           </div>
         </div>
 
@@ -293,9 +356,11 @@
           <p>{m.contact_note_talk()}</p>
           <div class="link-row">
             {#each socialLinks as link (link.href)}
+              {@const SocialIcon = link.icon}
               <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
               <a href={link.href} target="_blank" rel="noreferrer noopener">
-                {link.label}
+                <SocialIcon size="0.9rem" />
+                <span>{link.label}</span>
               </a>
             {/each}
           </div>
@@ -410,6 +475,9 @@
 
   .section-nav button,
   .link-row a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
     color: #f3f4f6;
     border-bottom: 1px solid #39414a;
     background: transparent;
@@ -449,6 +517,19 @@
     margin-bottom: 1rem;
   }
 
+  .section-heading {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.7rem;
+  }
+
+  .section-icon {
+    display: inline-flex;
+    color: #7f8894;
+    padding-top: 0.1rem;
+    flex-shrink: 0;
+  }
+
   .intro-grid {
     display: grid;
     grid-template-columns: minmax(0, 1.2fr) minmax(240px, 0.8fr);
@@ -465,6 +546,17 @@
     gap: 0.2rem;
   }
 
+  .fact-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+  }
+
+  .fact-label :global(svg) {
+    color: #6b7280;
+    flex-shrink: 0;
+  }
+
   .links-block,
   .contact-block {
     display: grid;
@@ -476,6 +568,16 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0.75rem 1rem;
+  }
+
+  .link-row a :global(svg) {
+    color: #8b949e;
+    transition: color 160ms ease;
+  }
+
+  .link-row a:hover :global(svg),
+  .link-row a:focus-visible :global(svg) {
+    color: #d1d5db;
   }
 
   .entry-list {


### PR DESCRIPTION
## Summary
- add a small local line-icon set for the homepage
- use icons only on section headers, intro facts, and social links
- keep navigation text-first and preserve the current minimal layout

## Testing
- pnpm run check
- pnpm run lint